### PR TITLE
Replace Class::Load with Module::Runtime

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,7 @@ Revision history for Perl extension {{$dist->name}}
 {{$NEXT}}
     - POD: add link to Pod::Weaver::PluginBundle::MARCEL
     - Test::PodSpelling: add stopwords 'CPAN', 'multi'
+    - Replace deprecated Class::Load::load_class with Module::Runtime::use_module
 
 1.121330  2012-05-12 00:06:22 Europe/Paris
     - minor internal build change: fixed stopwords locally in POD for a clean

--- a/lib/Dist/Zilla/PluginBundle/MARCEL.pm
+++ b/lib/Dist/Zilla/PluginBundle/MARCEL.pm
@@ -5,7 +5,7 @@ use warnings;
 package Dist::Zilla::PluginBundle::MARCEL;
 
 # ABSTRACT: Build and release a distribution like MARCEL
-use Class::Load ();  # load_class
+use Module::Runtime qw(use_module);
 use Moose;
 use Moose::Autobox;
 
@@ -174,7 +174,7 @@ sub bundle_config {
     for my $wanted (@wanted) {
         my ($name, $arg) = @$wanted;
         my $class = "Dist::Zilla::Plugin::$name";
-        Class::Load::load_class($class);    # make sure plugin exists
+        use_module($class);    # make sure plugin exists
         push @plugins, [ "$section->{name}/$name" => $class => $arg ];
     }
 


### PR DESCRIPTION
Class::Load::load_class is deprecated, so use Module::Runtime's
use_module instead.

Fixes RT #91004.
